### PR TITLE
Add metadata properties to `TestResultsModel` for CTRF reporting

### DIFF
--- a/TestResultModel.cs
+++ b/TestResultModel.cs
@@ -5,11 +5,11 @@ namespace DotnetCtrfJsonReporter
 {
     public class TestResultsModel
     {
-        public string SpecVersion => Assembly.GetExecutingAssembly()?.GetName()?.Version?.ToString() ?? "0.0.0";
-        public string ReportId => Guid.NewGuid().ToString();
-        public string Timestamp => DateTime.UtcNow.ToString("O");
-        public string ReportFormat => "CTRF";
-        public string GeneratedBy => "ctrf-json-reporter";
+        public static string SpecVersion => Assembly.GetExecutingAssembly()?.GetName()?.Version?.ToString() ?? "0.0.0";
+        public static string ReportId => Guid.NewGuid().ToString();
+        public static string Timestamp => DateTime.UtcNow.ToString("O");
+        public static string ReportFormat => "CTRF";
+        public static string GeneratedBy => "ctrf-json-reporter";
         public ResultsModel Results { get; set; } = new ResultsModel();
     }
 

--- a/TestResultModel.cs
+++ b/TestResultModel.cs
@@ -1,9 +1,15 @@
 using Newtonsoft.Json;
+using System.Reflection;
 
 namespace DotnetCtrfJsonReporter
 {
     public class TestResultsModel
     {
+        public string SpecVersion => Assembly.GetExecutingAssembly()?.GetName()?.Version?.ToString() ?? "0.0.0";
+        public string ReportId => Guid.NewGuid().ToString();
+        public string Timestamp => DateTime.UtcNow.ToString("O");
+        public string ReportFormat => "CTRF";
+        public string GeneratedBy => "ctrf-json-reporter";
         public ResultsModel Results { get; set; } = new ResultsModel();
     }
 


### PR DESCRIPTION
## Description

This pull request enhances the `TestResultsModel` class by adding metadata properties required for CTRF (Common Test Results Format) reporting.

### Added Properties

- `SpecVersion`: Automatically derived from the executing assembly version.
- `ReportId`: A unique identifier generated using `Guid.NewGuid()`.
- `Timestamp`: The UTC timestamp at the time of report generation (`DateTime.UtcNow`).
- `ReportFormat`: Hardcoded as `"CTRF"` to indicate the report format.
- `GeneratedBy`: Specifies the generator as `"ctrf-json-reporter"`.

These fields ensure that the generated JSON report conforms to the CTRF specification and includes relevant metadata for identification and traceability.
