### PR TITLE
Add optional properties that can be extracted from CTRF reporting

### DIFF
--- a/DotnetCtrfJsonReporter.csproj
+++ b/DotnetCtrfJsonReporter.csproj
@@ -5,7 +5,7 @@
     <PackageId>DotnetCtrfJsonReporter</PackageId>
     <OutputType>Exe</OutputType>
     <PackAsTool>true</PackAsTool>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <Version>0.0.4</Version>

--- a/JsonConverter.cs
+++ b/JsonConverter.cs
@@ -10,7 +10,8 @@ namespace DotnetCtrfJsonReporter
             var settings = new JsonSerializerSettings
             {
                 ContractResolver = new CamelCasePropertyNamesContractResolver(),
-                Formatting = Formatting.Indented
+                Formatting = Formatting.Indented,
+                NullValueHandling = NullValueHandling.Ignore
             };
 
             return JsonConvert.SerializeObject(testResults, settings);

--- a/README.md
+++ b/README.md
@@ -42,9 +42,9 @@ Explore more <a href="https://www.ctrf.io/integrations">integrations</a>
       "name": "mstest"
     },
     "summary": {
-      "tests": 1,
+      "tests": 2,
       "passed": 1,
-      "failed": 0,
+      "failed": 1,
       "pending": 0,
       "skipped": 0,
       "other": 0,
@@ -55,7 +55,25 @@ Explore more <a href="https://www.ctrf.io/integrations">integrations</a>
       {
         "name": "ctrf should generate the same report with any tool",
         "status": "passed",
-        "duration": 100
+        "duration": 100,
+        "start": 1706828654500,
+        "stop": 1706828654600,
+        "suite": "UnitTests",
+        "rawStatus": "Passed",
+        "filePath": "/path/to/test.cs"
+      },
+      {
+        "name": "failing test example",
+        "status": "failed",
+        "duration": 50,
+        "start": 1706828654600,
+        "stop": 1706828654650,
+        "suite": "UnitTests",
+        "message": "Expected: True\nActual: False",
+        "trace": "   at FailingTest() in /path/to/test.cs:line 42",
+        "line": 42,
+        "rawStatus": "Failed",
+        "filePath": "/path/to/test.cs"
       }
     ],
     "environment": {
@@ -129,11 +147,19 @@ dotnet tool run DotnetCtrfJsonReporter \
 
 The test object in the report includes the following [CTRF properties](https://ctrf.io/docs/schema/test):
 
-| Name       | Type   | Required | Details                                                                             |
-| ---------- | ------ | -------- | ----------------------------------------------------------------------------------- |
-| `name`     | String | Required | The name of the test.                                                               |
-| `status`   | String | Required | The outcome of the test. One of: `passed`, `failed`, `skipped`, `pending`, `other`. |
-| `duration` | Number | Required | The time taken for the test execution, in milliseconds.                             |
+| Name         | Type   | Required | Details                                                                             |
+| ------------ | ------ | -------- | ----------------------------------------------------------------------------------- |
+| `name`       | String | Required | The name of the test.                                                               |
+| `status`     | String | Required | The outcome of the test. One of: `passed`, `failed`, `skipped`, `pending`, `other`. |
+| `duration`   | Number | Required | The time taken for the test execution, in milliseconds.                             |
+| `start`      | Number | Optional | Test start time as epoch milliseconds.                                              |
+| `stop`       | Number | Optional | Test end time as epoch milliseconds.                                                |
+| `suite`      | String | Optional | The test suite or class name (extracted from TestMethod className).                |
+| `message`    | String | Optional | Error message for failed tests. Only included when the test fails.                 |
+| `trace`      | String | Optional | Stack trace for failed tests. Only included when the test fails.                   |
+| `line`       | Number | Optional | Line number where the test failure occurred (extracted from stack trace).          |
+| `rawStatus`  | String | Optional | Original TRX outcome status (e.g., "Passed", "Failed", "NotExecuted").             |
+| `filePath`   | String | Optional | Path to the test source file (extracted from stack trace or codeBase).            |
 
 ## Support Us
 

--- a/TestProcessor.cs
+++ b/TestProcessor.cs
@@ -1,4 +1,5 @@
 using System.Xml.Linq;
+using System.Text.RegularExpressions;
 
 namespace DotnetCtrfJsonReporter
 {
@@ -7,24 +8,111 @@ namespace DotnetCtrfJsonReporter
         public List<TestModel> ProcessTests(XDocument trxDocument)
         {
             var testResults = trxDocument.Descendants().Where(d => d.Name.LocalName == "UnitTestResult");
+            var testDefinitions = trxDocument.Descendants().Where(d => d.Name.LocalName == "UnitTest");
             var testModels = new List<TestModel>();
 
             foreach (var testResult in testResults)
             {
                 var durationString = testResult.Attribute("duration")?.Value ?? "00:00:00";
                 var totalMilliseconds = ParseTotalMilliseconds(durationString);
+                
+                var testId = testResult.Attribute("testId")?.Value;
+                var testDefinition = testDefinitions.FirstOrDefault(td => td.Attribute("id")?.Value == testId);
 
                 var testModel = new TestModel
                 {
-                    Name = testResult.Attribute("testName")?.Value,
-                    Status = StatusMapper.MapToCtrfStatus(testResult.Attribute("outcome")?.Value),
-                    Duration = totalMilliseconds
+                    Name = testResult.Attribute("testName")?.Value ?? string.Empty,
+                    Status = StatusMapper.MapToCtrfStatus(testResult.Attribute("outcome")?.Value ?? string.Empty),
+                    Duration = totalMilliseconds,
+                    RawStatus = testResult.Attribute("outcome")?.Value
                 };
+
+                // Extract timing information
+                if (DateTime.TryParse(testResult.Attribute("startTime")?.Value, out DateTime startTime))
+                {
+                    testModel.Start = ConvertToEpochMilliseconds(startTime);
+                }
+                
+                if (DateTime.TryParse(testResult.Attribute("endTime")?.Value, out DateTime endTime))
+                {
+                    testModel.Stop = ConvertToEpochMilliseconds(endTime);
+                }
+
+                // Extract suite information from test definition
+                if (testDefinition != null)
+                {
+                    var testMethod = testDefinition.Descendants().FirstOrDefault(d => d.Name.LocalName == "TestMethod");
+                    var className = testMethod?.Attribute("className")?.Value;
+                    if (!string.IsNullOrEmpty(className))
+                    {
+                        // Extract just the class name without namespace
+                        var classNameParts = className.Split('.');
+                        testModel.Suite = classNameParts.Length > 0 ? classNameParts.Last() : className;
+                    }
+
+                    // Extract file path from codeBase
+                    var codeBase = testMethod?.Attribute("codeBase")?.Value;
+                    if (!string.IsNullOrEmpty(codeBase))
+                    {
+                        testModel.FilePath = codeBase;
+                    }
+                }
+
+                // Extract error information for failed tests
+                var errorInfo = testResult.Descendants().FirstOrDefault(d => d.Name.LocalName == "ErrorInfo");
+                if (errorInfo != null)
+                {
+                    var messageElement = errorInfo.Descendants().FirstOrDefault(d => d.Name.LocalName == "Message");
+                    var stackTraceElement = errorInfo.Descendants().FirstOrDefault(d => d.Name.LocalName == "StackTrace");
+                    
+                    testModel.Message = messageElement?.Value;
+                    testModel.Trace = stackTraceElement?.Value;
+
+                    // Extract line number and file path from stack trace
+                    if (!string.IsNullOrEmpty(testModel.Trace))
+                    {
+                        var lineInfo = ExtractLineAndFileFromStackTrace(testModel.Trace);
+                        if (lineInfo.Line.HasValue)
+                        {
+                            testModel.Line = lineInfo.Line;
+                        }
+                        if (!string.IsNullOrEmpty(lineInfo.FilePath))
+                        {
+                            // Prefer source file path from stack trace over DLL path
+                            testModel.FilePath = lineInfo.FilePath;
+                        }
+                    }
+                }
 
                 testModels.Add(testModel);
             }
 
             return testModels;
+        }
+
+        private (int? Line, string? FilePath) ExtractLineAndFileFromStackTrace(string stackTrace)
+        {
+            // Pattern to match: "at MethodName() in /path/to/file.cs:line 42"
+            var pattern = @"at .+ in (.+):line (\d+)";
+            var match = Regex.Match(stackTrace, pattern);
+            
+            if (match.Success)
+            {
+                var filePath = match.Groups[1].Value;
+                if (int.TryParse(match.Groups[2].Value, out int lineNumber))
+                {
+                    return (lineNumber, filePath);
+                }
+                return (null, filePath);
+            }
+            
+            return (null, null);
+        }
+
+        private long ConvertToEpochMilliseconds(DateTime dateTime)
+        {
+            var epoch = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+            return (long)(dateTime.ToUniversalTime() - epoch).TotalMilliseconds;
         }
 
         private int ParseTotalMilliseconds(string durationString)

--- a/TestResultModel.cs
+++ b/TestResultModel.cs
@@ -17,6 +17,14 @@ namespace DotnetCtrfJsonReporter
         public string Name { get; set; }
         public string Status { get; set; }
         public long Duration { get; set; }
+        public long? Start { get; set; }
+        public long? Stop { get; set; }
+        public string? Suite { get; set; }
+        public string? Message { get; set; }
+        public string? Trace { get; set; }
+        public int? Line { get; set; }
+        public string? RawStatus { get; set; }
+        public string? FilePath { get; set; }
     }
 
     public class ToolModel


### PR DESCRIPTION
This adds the optional properties from ctrf.io schema 

What is added:
- `start` - test start time timestamp
- `stop` - timestamp when the test execution has finished
- `suite` - the test class name
- `line` - line number where the error occured
- `rawStatus` - TRX extracted outcome
- `filePath` - test source code file path

Note: The code currently uses `DateTime` without checking and/or correcting the timezone, so I can't be sure if that will be in local or UTC time, but should be consistent across the same executing environment, like the same OS and dotnet version.